### PR TITLE
Fixed: template rendering fails when no jsonify_format is specified in application config

### DIFF
--- a/lib/jsonify-rails/jsonify_builder.rb
+++ b/lib/jsonify-rails/jsonify_builder.rb
@@ -7,8 +7,12 @@ module ActionView
 
         self.default_format = Mime::JSON
 
+        def format
+          Rails.application.config.respond_to?(:jsonify_format) ? Rails.application.config.jsonify_format : 'plain'
+        end
+
         def compile(template)
-          "json = ::Jsonify::Builder.new(:format => :#{(Rails.application.config.jsonify_format || 'plain')});" +
+          "json = ::Jsonify::Builder.new(:format => :#{format});" +
             template.source +
           ";json.compile!;"
         end
@@ -18,9 +22,13 @@ module ActionView
         def default_format
           Mime::JSON
         end
+        
+        def format
+          Rails.application.config.respond_to?(:jsonify_format) ? Rails.application.config.jsonify_format : 'plain'
+        end
 
         def self.call(template)
-          "json = ::Jsonify::Builder.new(:format => :#{(Rails.application.config.jsonify_format || 'plain')});" +
+          "json = ::Jsonify::Builder.new(:format => :#{format});" +
             template.source +
           ";json.compile!;"
         end


### PR DESCRIPTION
In your last commit you added the option to specify different format (plain or pretty). The problem is that if the value isn't set your gem causes an exception:

`ActionView::Template::Error (undefined method 'jsonify_format' for #<Rails::Application::Configuration:0x000001027b81a0>):
  railties (3.0.4) lib/rails/railtie/configuration.rb:77:in 'method_missing'
  jsonify-rails (0.0.8) lib/jsonify-rails/jsonify_builder.rb:11:in 'compile'`
(this is an excerpt from the error traceback)

Anyway, this commit should fix it. At least for Rails 3.0.
