### PR TITLE
Fixed an error when calling 'format' from the builder.

### DIFF
--- a/lib/jsonify-rails/jsonify_builder.rb
+++ b/lib/jsonify-rails/jsonify_builder.rb
@@ -23,7 +23,7 @@ module ActionView
           Mime::JSON
         end
         
-        def format
+        def self.format
           Rails.application.config.respond_to?(:jsonify_format) ? Rails.application.config.jsonify_format : 'plain'
         end
 


### PR DESCRIPTION
too few arguments (line #30)

30        def self.call(template)
31          "json = ::Jsonify::Builder.new(:format => :#{format});" +
32            template.source +
33          ";json.compile!;"
