### PR TITLE
Ignore trailing whitespace in templates

### DIFF
--- a/lib/jsonify-rails/jsonify_builder.rb
+++ b/lib/jsonify-rails/jsonify_builder.rb
@@ -10,7 +10,7 @@ module ActionView
         def compile(template)
           "json = ::Jsonify::Builder.new(:format => :#{jsonify_format});" +
             template.source +
-          ";json.compile!;"
+          ";\njson.compile!;"
         end
         
         private 
@@ -29,7 +29,7 @@ module ActionView
         def self.call(template)
           "json = ::Jsonify::Builder.new(:format => :#{jsonify_format});" +
             template.source +
-          ";json.compile!;"
+          ";\njson.compile!;"
         end
         
         private 

--- a/spec/jsonify_builder_spec.rb
+++ b/spec/jsonify_builder_spec.rb
@@ -11,6 +11,10 @@ describe 'Jsonify template handler' do
     ViewTemplate.new("json.hello 'world'")
   end
 
+  let( :template_with_trailing_comment ) do
+    ViewTemplate.new("json.hello 'world' #trailing comment")
+  end
+
   context "#{Rails.version}" do
     before do
       Rails.stub_chain(:application, :config, :jsonify_format).and_return( :plain )
@@ -22,6 +26,11 @@ describe 'Jsonify template handler' do
 
     it 'should compile to JSON' do
       result = eval( Handler.call template )
+      result.should == '{"hello":"world"}'
+    end
+
+    it 'should ignore trailing comments' do
+      result = eval( Handler.call template_with_trailing_comment )
       result.should == '{"hello":"world"}'
     end
 


### PR DESCRIPTION
Hey Bill!

I was using jsonify in a Rails app and noticed when I had trailing comment in a partial it wouldn't pull in the partial correctly. So upon further investigation, looks like the json.compile! line wasn't getting called. Here's a small fix for that issue.

Thanks!
