### PR TITLE
Fix single arity template handler deprecation warning with Rails 6.0 

### DIFF
--- a/lib/jsonify-rails/jsonify_builder.rb
+++ b/lib/jsonify-rails/jsonify_builder.rb
@@ -26,9 +26,10 @@ module ActionView
           Mime::JSON
         end
         
-        def self.call(template)
+        def self.call(template, source = nil)
+          source ||= template.source
           "json = ::Jsonify::Builder.new(:format => :#{jsonify_format});" +
-            template.source +
+            source +
           ";\njson.compile!;"
         end
         


### PR DESCRIPTION
Here I am getting this deprecation warning 
```
DEPRECATION WARNING: Single arity template handlers are deprecated. Template handlers must
now accept two parameters, the view object and the source for the view object.
Change:
  >> ActionView::Template::Handlers::JsonifyBuilder.call(template)
To:
  >> ActionView::Template::Handlers::JsonifyBuilder.call(template, source)
```
when I start the server. 

It has been resolved by other template gems - 

cofee-rails https://github.com/rails/coffee-rails/commit/cbf6af63ac57cea246b75275ba50769d12f43316
prawn-rails https://github.com/cortiz/prawn-rails/pull/39/commits/9be20878ab6c9ee337c4c3dfb3e983ee1921f0e9

I have used a similar approach to resolve this here. Please let me know if this works.

